### PR TITLE
Add basic GLM-OCR support

### DIFF
--- a/benchmarks/ocr/output-glm-ocr.jsonl
+++ b/benchmarks/ocr/output-glm-ocr.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c26f1a7badc38283801d3d9c8b5449b1b1119e31a4eca27369124fdc0f6af33b
+size 188536

--- a/benchmarks/ocr/results.html
+++ b/benchmarks/ocr/results.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1a1ff806de25ffabf80b27479d325e9a5811d788d8679e3f09c32760e2b3ca3
-size 2952193
+oid sha256:682232bd702c6b82d5a0035a1c35d138efe66c8c4be70112188e0b6e2453683a
+size 3541967

--- a/plans/GLM_OCR.md
+++ b/plans/GLM_OCR.md
@@ -1,0 +1,158 @@
+# GLM-OCR Support
+
+> **Status**: Implemented.
+
+## Problem
+
+GLM-OCR is a highly specialized model served via an OpenAI-compatible `/v1/chat/completions` endpoint. Its OCR mode uses a fixed prompt (`"Text Recognition:"`) with a single attached image, and returns raw text (no JSON structure, no schema). This doesn't fit the existing `ChatPrompt` → `Driver::chat_completion()` → JSON schema validation pipeline.
+
+We need a new code path for raw-text LLM OCR that:
+- Bypasses prompt templating, JSON schema, and schema validation
+- Still gets PDF splitting, page-level concurrency, timeouts, rate limiting, memory limits, and retry logic
+- Reuses the existing `genai` client for OpenAI-compatible API calls
+
+## Architecture
+
+### New trait: `RawDriver` (implemented by `NativeDriver`)
+
+A minimal driver trait for single-image, raw-text completion requests:
+
+```rust
+#[async_trait]
+pub trait RawDriver: Send + Sync + 'static {
+    async fn raw_completion(
+        &self,
+        model: &str,
+        text: &str,          // fixed prompt text (e.g. "Text Recognition:")
+        image: &ImageFile,   // page image
+        llm_opts: &LlmOpts,
+        mem_limiter: &MemLimiter,
+    ) -> Result<RawCompletionResponse, DriverError>;
+}
+
+pub struct RawCompletionResponse {
+    pub text: String,
+    pub token_usage: Option<TokenUsage>,
+}
+```
+
+This is intentionally narrow — no `ChatPrompt`, no `Schema`, no `ChatRequest` construction. The engine caller assembles the message.
+
+### Implementation: `impl RawDriver for NativeDriver`
+
+Rather than creating a new driver type, implement `RawDriver` directly on the existing `NativeDriver`. It already owns the `genai::Client` with `OPENAI_API_BASE` / `OPENAI_API_KEY` routing via `ServiceTargetResolver`. The `raw_completion` impl:
+- Constructs a simple `ChatRequest` with one user message (text + image)
+- Omit `ChatResponseFormat::JsonSpec` — gets raw text
+- Calls `chat_res.first_text()` instead of JSON parsing
+- Honors `--llm-timeout`, `--temperature`, `--max-completion-tokens`, `--top-p` via `ChatOptions`
+- Reuses `IsKnownTransient` impl for `genai::Error` for retry classification
+
+This lets GLM-OCR be routed through any OpenAI-compatible gateway (vLLM, LiteLLM, Ollama) just by setting env vars, and shares the same client construction and auth logic as the existing structured-chat path.
+
+### New engine: `RawDriverOcrPageEngine`
+
+An `OcrPageEngine` implementation that wraps a `Box<dyn RawDriver>` and a fixed prompt string:
+
+```rust
+pub struct RawDriverOcrPageEngine {
+    driver: Box<dyn RawDriver>,
+    prompt_text: String,
+    rate_limiter: RateLimiter,
+    mem_limiter: MemLimiter,
+}
+```
+
+The `ocr_page()` impl, acquiring permits in the same order as Textract:
+1. Acquire rate limit permit (`rate_limiter.acquire_one().await`)
+2. Load image (`image.load(ImageEncoding::Base64, &mem_limiter).await`) — acquires mem_limiter
+3. Call `driver.raw_completion(&model, &prompt_text, &image, ...)`
+4. Return `OcrPageOutput { text: Some(response.text), token_usage: response.token_usage, ..default() }`
+
+The rate limiter is acquired before the mem_limiter, matching the Textract order. The `rate_limiter.acquire_one()` is a blocking wait (not a held permit), so there's no risk of circular wait — but consistent ordering across engines eliminates any deadlock surface if the rate limiter implementation changes. No JSON parsing, no `OcrAnalysis` extraction, no schema validation.
+
+### Engine routing
+
+In `engines/mod.rs::ocr_engine_for_model()`, match on `ocr_opts.model` with a case-insensitive substring check:
+
+```rust
+if ocr_opts.model.to_lowercase().contains("glm-ocr") => {
+    let prompt_text = GLM_OCR_PROMPT; // "Text Recognition:"
+    split_pages(RawDriverOcrPageEngine::new(
+        concurrency_limit,
+        prompt_text,
+        ocr_opts,
+    ).await?)
+}
+```
+
+The substring match (rather than exact model name) accommodates variants like `glm-4.5-ocr`, `glm-ocr-2`, etc. without code changes.
+
+## Shared infrastructure factoring
+
+### Move `create_rate_limiter` to `engines/page.rs`
+
+The helper currently lives in `engines/textract.rs`. Both Textract and GLM-OCR (and any future non-chat `OcrPageEngine`) need it. Move it to `page.rs` alongside the `OcrPageEngine` trait:
+
+```rust
+// In engines/page.rs
+pub fn create_rate_limiter(concurrency_limit: usize, llm_opts: &LlmOpts) -> RateLimiter {
+    let rate_limit = llm_opts.rate_limit.clone()
+        .unwrap_or_else(|| RateLimit::new(concurrency_limit, RateLimitPeriod::Second));
+    rate_limit.to_rate_limiter()
+}
+```
+
+Update `textract.rs` to import from `super::page` instead of defining it inline.
+
+### Controls inherited from `SplitPagesOcrEngine`
+
+The `RawDriverOcrPageEngine` gets these for free by being wrapped in `SplitPagesOcrEngine`:
+
+| Control | Source |
+|---------|--------|
+| `--jobs N` (in-flight page limit) | `SplitPagesOcrEngine::buffered(concurrency_limit)` |
+| `--page-timeout` | `SplitPagesOcrEngine::with_timeout()` per page |
+| `--doc-timeout` | `ocr_file()::with_timeout()` per document |
+| `--page-memory-limit` | `RawDriverOcrPageEngine::mem_limiter` (same as Textract) |
+
+### Controls handled inside `RawDriverOcrPageEngine`
+
+| Control | Source |
+|---------|--------|
+| `--rate-limit` | `rate_limiter.acquire_one().await` before each API call |
+| `--llm-timeout` | Applied inside `GenaiRawDriver::raw_completion()` (same as `NativeDriver`) |
+| `--temperature` / `--max-completion-tokens` / `--top-p` | Passed via `llm_opts` to `ChatOptions` |
+
+### Controls NOT applicable
+
+| Control | Reason |
+|---------|--------|
+| `--prompt` / prompt file | GLM-OCR uses a fixed hardcoded prompt |
+| `response_schema` | Output is raw text, no schema |
+| `--driver` (bedrock/vertex) | GLM-OCR is OpenAI-compatible only; routed via `OPENAI_API_BASE` |
+
+## Files affected
+
+### New files
+
+(No new files.)
+
+### Modified files
+
+- `src/drivers/mod.rs` — Add `RawDriver` trait and `RawCompletionResponse` type
+- `src/drivers/native.rs` — Add `impl RawDriver for NativeDriver`
+- `src/queues/ocr/engines/page.rs` — Move `create_rate_limiter` here (from `textract.rs`)
+- `src/queues/ocr/engines/raw.rs` — `RawDriverOcrPageEngine` implementation
+- `src/queues/ocr/engines/mod.rs` — Export `raw` module; add `glm-ocr` routing in `ocr_engine_for_model()`
+- `src/queues/ocr/engines/textract.rs` — Import `create_rate_limiter` from `super::page` instead of defining inline
+
+### No changes needed
+
+- `src/cmd/ocr.rs` — No new CLI flags; all controls (`--jobs`, `--rate-limit`, `--page-timeout`, `--doc-timeout`, `--page-memory-limit`, `--llm-timeout`) already exist
+- `src/queues/ocr/engines/split_pages.rs` — Works with any `OcrPageEngine`
+- `src/queues/ocr/mod.rs` — Engine routing is opaque
+
+## Future work (deferred)
+
+- **Information-extraction mode**: GLM-OCR supports a semi-fixed prompt with JSON structure (e.g. `"请按下列JSON格式输出图中信息: { ... }"`). This could be supported by a `StructuredRawDriver` that takes a JSON schema but still uses a simple prompt string. Defer until there's demand.
+- **Batch image support**: GLM-OCR is single-image. If multi-image support is needed, the `RawDriver` trait would need to expand to accept `Vec<ImageFile>`.

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -13,7 +13,8 @@ use serde::Serialize;
 
 use crate::{
     costs::ModelCost,
-    mem_limit::{MemLimit, MemLimiter},
+    images::ImageFile,
+    mem_limit::{MEM_PERMIT_DEADLOCK_TIMEOUT, MemLimit, MemLimiter},
     prelude::*,
     prompt::{ChatPrompt, Rendered},
     rate_limit::RateLimit,
@@ -164,6 +165,14 @@ impl LlmOpts {
     /// Get the timeout as a [`Duration`], if set.
     pub fn llm_timeout_duration(&self) -> Option<Duration> {
         self.llm_timeout.map(Duration::from_secs)
+    }
+
+    /// Construct our memory limiter.
+    pub fn mem_limiter(&self) -> MemLimiter {
+        self.page_memory_limit
+            .as_ref()
+            .map(|ml| ml.to_mem_limiter(Some(MEM_PERMIT_DEADLOCK_TIMEOUT)))
+            .unwrap_or_else(MemLimiter::unlimited)
     }
 
     /// Compute and store our canonical base directory for later use.
@@ -343,6 +352,33 @@ pub struct ChatCompletionResponse {
     /// Structured response from the LLM. This will not have been
     /// validated yet.
     pub response: Value,
+
+    /// Token usage.
+    pub token_usage: Option<TokenUsage>,
+}
+
+/// Interface trait for raw (unstructured) LLM completion.
+///
+/// Used by OCR engines that need a simple text + image → text path
+/// without ChatPrompt templating, JSON schemas, or schema validation.
+#[async_trait]
+pub trait RawDriver: Send + Sync + 'static {
+    /// Run a raw completion request with a single text prompt and image.
+    async fn raw_completion(
+        &self,
+        model: &str,
+        text: &str,
+        image: &ImageFile,
+        llm_opts: &LlmOpts,
+        mem_limiter: &MemLimiter,
+    ) -> Result<RawCompletionResponse, DriverError>;
+}
+
+/// A raw completion response (unstructured text).
+#[derive(Debug)]
+pub struct RawCompletionResponse {
+    /// Raw text response from the LLM.
+    pub text: String,
 
     /// Token usage.
     pub token_usage: Option<TokenUsage>,

--- a/src/drivers/native.rs
+++ b/src/drivers/native.rs
@@ -24,7 +24,10 @@ use crate::{
     schema::get_schema_title,
 };
 
-use super::{ChatCompletionResponse, Driver, DriverError, LlmOpts, TokenUsage};
+use super::{
+    ChatCompletionResponse, Driver, DriverError, LlmOpts, RawCompletionResponse,
+    RawDriver, TokenUsage,
+};
 
 /// Our native driver, using the `genai` crate.
 #[derive(Debug)]
@@ -58,6 +61,38 @@ impl NativeDriver {
             .with_service_target_resolver(target_resolver)
             .build();
         Ok(Self { client })
+    }
+
+    /// Build [`ChatOptions`] from our common LLM options and a response format.
+    fn chat_options(
+        llm_opts: &LlmOpts,
+        response_format: Option<ChatResponseFormat>,
+    ) -> ChatOptions {
+        ChatOptions {
+            temperature: llm_opts.temperature.map(f64::from),
+            max_tokens: llm_opts.max_completion_tokens,
+            top_p: llm_opts.top_p.map(f64::from),
+            reasoning_effort: llm_opts.reasoning_effort.clone(),
+            response_format,
+            ..ChatOptions::default()
+        }
+    }
+
+    /// Extract [`TokenUsage`] from a [`Usage`] struct.
+    fn extract_token_usage(usage: Usage) -> Option<TokenUsage> {
+        if let Usage {
+            prompt_tokens: Some(prompt_tokens),
+            completion_tokens: Some(completion_tokens),
+            ..
+        } = usage
+        {
+            Some(TokenUsage {
+                prompt_tokens: u64::try_from(prompt_tokens).unwrap_or_default(),
+                completion_tokens: u64::try_from(completion_tokens).unwrap_or_default(),
+            })
+        } else {
+            None
+        }
     }
 }
 
@@ -95,18 +130,14 @@ impl Driver for NativeDriver {
             .to_genai_request(mem_limiter)
             .await
             .map_err(DriverError::invalid_input)?;
-        let opts = ChatOptions {
-            temperature: llm_opts.temperature.map(f64::from),
-            max_tokens: llm_opts.max_completion_tokens,
-            top_p: llm_opts.top_p.map(f64::from),
-            reasoning_effort: llm_opts.reasoning_effort.clone(),
-            response_format: Some(ChatResponseFormat::JsonSpec(JsonSpec {
+        let opts = Self::chat_options(
+            llm_opts,
+            Some(ChatResponseFormat::JsonSpec(JsonSpec {
                 name: get_schema_title(&schema),
                 description: None,
                 schema,
             })),
-            ..ChatOptions::default()
-        };
+        );
 
         // Run our LLM request.
         let chat_res = self
@@ -130,6 +161,79 @@ impl Driver for NativeDriver {
         debug!(%response, "Response");
 
         // Compute our token usage.
+        let token_usage = Self::extract_token_usage(chat_res.usage);
+
+        Ok(ChatCompletionResponse {
+            response,
+            token_usage,
+        })
+    }
+}
+
+#[async_trait]
+impl RawDriver for NativeDriver {
+    #[instrument(level = "debug", skip_all)]
+    async fn raw_completion(
+        &self,
+        model: &str,
+        text: &str,
+        image: &ImageFile,
+        llm_opts: &LlmOpts,
+        mem_limiter: &MemLimiter,
+    ) -> Result<RawCompletionResponse, DriverError> {
+        // Load the image data.
+        let image_data = image
+            .load(ImageEncoding::Base64, mem_limiter)
+            .await
+            .map_err(DriverError::invalid_input)?;
+        let base64_str = std::str::from_utf8(image_data.data())
+            .context("base64 image data is not valid UTF-8")
+            .map_err(DriverError::invalid_input)?;
+
+        // Build a simple user message with text + image.
+        let parts = vec![
+            ContentPart::Text(text.to_owned()),
+            ContentPart::from_binary_base64(
+                image_data.mime_type().to_owned(),
+                Arc::from(base64_str),
+                None,
+            ),
+        ];
+        let req = ChatRequest {
+            system: None,
+            messages: vec![ChatMessage {
+                role: ChatRole::User,
+                content: MessageContent::from_parts(parts),
+                options: None,
+            }],
+            ..ChatRequest::default()
+        };
+
+        // Build options — no response_format (raw text, not JSON).
+        let opts = ChatOptions {
+            temperature: llm_opts.temperature.map(f64::from),
+            max_tokens: llm_opts.max_completion_tokens,
+            top_p: llm_opts.top_p.map(f64::from),
+            reasoning_effort: llm_opts.reasoning_effort.clone(),
+            response_format: None, // raw text, not JSON
+            ..ChatOptions::default()
+        };
+
+        // Run the request.
+        let chat_res = self
+            .client
+            .exec_chat(model, req, Some(&opts))
+            .await
+            .map_err(DriverError::api)?;
+
+        // Extract raw text response.
+        let text = chat_res
+            .first_text()
+            .ok_or_else(|| anyhow!("No text content in response: {:?}", chat_res))
+            .map_err(DriverError::invalid_output)?;
+        debug!(%text, "Raw response");
+
+        // Compute token usage.
         let token_usage = if let Usage {
             prompt_tokens: Some(prompt_tokens),
             completion_tokens: Some(completion_tokens),
@@ -144,8 +248,8 @@ impl Driver for NativeDriver {
             None
         };
 
-        Ok(ChatCompletionResponse {
-            response,
+        Ok(RawCompletionResponse {
+            text: text.to_owned(),
             token_usage,
         })
     }

--- a/src/queues/ocr/engines/llm.rs
+++ b/src/queues/ocr/engines/llm.rs
@@ -8,7 +8,6 @@ use serde_json::Map;
 use crate::{
     async_utils::JoinWorker,
     cmd::ocr::OcrOpts,
-    mem_limit::{MEM_PERMIT_DEADLOCK_TIMEOUT, MemLimiter},
     prelude::*,
     prompt::ChatPrompt,
     queues::{
@@ -61,12 +60,7 @@ impl LlmOcrPageEngine {
 
         // Construct a real MemLimiter for the OCR path. Each page has exactly
         // one image, so there's no multi-image deadlock risk.
-        let mem_limiter = ocr_opts
-            .llm_opts
-            .page_memory_limit
-            .as_ref()
-            .map(|ml| ml.to_mem_limiter(Some(MEM_PERMIT_DEADLOCK_TIMEOUT)))
-            .unwrap_or_else(MemLimiter::unlimited);
+        let mem_limiter = ocr_opts.llm_opts.mem_limiter();
 
         // Create a new chat queue to handle all our LLM requests.
         let (chat_queue, worker) = create_chat_work_queue(

--- a/src/queues/ocr/engines/mod.rs
+++ b/src/queues/ocr/engines/mod.rs
@@ -10,6 +10,7 @@ pub mod file;
 pub mod llm;
 pub mod page;
 pub mod pdftotext;
+pub mod raw;
 pub mod split_pages;
 pub mod tesseract;
 pub mod textract;
@@ -45,6 +46,19 @@ pub async fn ocr_engine_for_model(
         "textract-async" => {
             textract::TextractOcrFileEngine::new(concurrency_limit, ocr_opts).await?
         }
+        // KLUDGE: There's a class of specialized OCR models that pretend to be
+        // LLMs but which need special drivers with fixed prompts. We recognize
+        // these by looking for known strings in their model names, at least for
+        // now. We may regret this later. We only plan to handle a small number
+        // of open models with very good benchmark scores.
+        model_name if model_name.to_lowercase().contains("glm-ocr") => split_pages(
+            raw::RawDriverOcrPageEngine::new(
+                concurrency_limit,
+                "Text Recognition:",
+                ocr_opts,
+            )
+            .await?,
+        ),
         // Assume all other OCR models are LLMs.
         _ => split_pages(
             llm::LlmOcrPageEngine::new(concurrency_limit, prompt, ocr_opts).await?,

--- a/src/queues/ocr/engines/mod.rs
+++ b/src/queues/ocr/engines/mod.rs
@@ -51,6 +51,9 @@ pub async fn ocr_engine_for_model(
         // these by looking for known strings in their model names, at least for
         // now. We may regret this later. We only plan to handle a small number
         // of open models with very good benchmark scores.
+        //
+        // Note that running these models standalone _without_ a page segmentation
+        // algorithm produces mediocre results.
         model_name if model_name.to_lowercase().contains("glm-ocr") => split_pages(
             raw::RawDriverOcrPageEngine::new(
                 concurrency_limit,

--- a/src/queues/ocr/engines/page.rs
+++ b/src/queues/ocr/engines/page.rs
@@ -1,6 +1,13 @@
 //! Interface for OCRing a single page.
 
-use crate::{drivers::TokenUsage, images::ImageFile, prelude::*};
+use leaky_bucket::RateLimiter;
+
+use crate::{
+    drivers::{LlmOpts, TokenUsage},
+    images::ImageFile,
+    prelude::*,
+    rate_limit::{RateLimit, RateLimitPeriod},
+};
 
 use super::super::OcrAnalysis;
 
@@ -39,4 +46,20 @@ pub struct OcrPageOutput {
 pub trait OcrPageEngine: Send + Sync + 'static {
     /// OCR a single page.
     async fn ocr_page(&self, input: OcrPageInput) -> Result<OcrPageOutput>;
+}
+
+/// Create a rate limiter, defaulting to concurrency-limit requests per second.
+///
+/// Shared by non-chat OcrPageEngine implementations (textract, raw driver, etc.)
+/// that need per-request rate limiting but don't go through the chat work queue.
+pub fn create_rate_limiter(concurrency_limit: usize, llm_opts: &LlmOpts) -> RateLimiter {
+    // If we don't have a rate limit, set one based on the concurrency limit.
+    //
+    // TODO: FUTURE BREAKING: We may want to remove the default rate limit, but
+    // that would be a breaking change.
+    let rate_limit = llm_opts
+        .rate_limit
+        .clone()
+        .unwrap_or_else(|| RateLimit::new(concurrency_limit, RateLimitPeriod::Second));
+    rate_limit.to_rate_limiter()
 }

--- a/src/queues/ocr/engines/raw.rs
+++ b/src/queues/ocr/engines/raw.rs
@@ -1,0 +1,102 @@
+//! OCR engine wrapping a [`RawDriver`] for unstructured text completion.
+//!
+//! Used for models like GLM-OCR that accept a single image with a fixed text
+//! prompt and return raw text (no JSON schema). These are not _really_ LLMs,
+//! but they pretend to be LLMs, and they often provide excellent OCR at low
+//! parameter counts. See also PaddleOCR, which could likely share much of this.
+
+use std::sync::Arc;
+
+use leaky_bucket::RateLimiter;
+
+use crate::{
+    async_utils::JoinWorker, cmd::ocr::OcrOpts, drivers::RawDriver,
+    mem_limit::MemLimiter, prelude::*,
+};
+
+use super::page::{OcrPageEngine, OcrPageInput, OcrPageOutput, create_rate_limiter};
+
+/// OCR engine wrapping a [`RawDriver`] for raw-text completion requests.
+pub struct RawDriverOcrPageEngine {
+    /// The raw driver to use for completion.
+    driver: Box<dyn RawDriver>,
+
+    /// The fixed prompt text sent with each request.
+    prompt_text: String,
+
+    /// A rate limiter to avoid hitting API limits.
+    rate_limiter: RateLimiter,
+
+    /// A memory limiter for image loading.
+    mem_limiter: MemLimiter,
+
+    /// OCR options (model name, LLM opts, etc.).
+    ocr_opts: Arc<OcrOpts>,
+}
+
+impl RawDriverOcrPageEngine {
+    /// Create a new raw-driver OCR engine.
+    #[allow(clippy::new_ret_no_self)]
+    pub async fn new(
+        concurrency_limit: usize,
+        prompt_text: impl Into<String>,
+        ocr_opts: Arc<OcrOpts>,
+    ) -> Result<(Arc<dyn OcrPageEngine>, JoinWorker)> {
+        use crate::drivers::native::NativeDriver;
+
+        let driver = Box::new(NativeDriver::new().await?) as Box<dyn RawDriver>;
+        let rate_limiter = create_rate_limiter(concurrency_limit, &ocr_opts.llm_opts);
+        let mem_limiter = ocr_opts.llm_opts.mem_limiter();
+
+        Ok((
+            Arc::new(Self {
+                driver,
+                prompt_text: prompt_text.into(),
+                rate_limiter,
+                mem_limiter,
+                ocr_opts,
+            }),
+            JoinWorker::noop(),
+        ))
+    }
+}
+
+#[async_trait]
+impl OcrPageEngine for RawDriverOcrPageEngine {
+    #[instrument(level = "debug", skip_all)]
+    async fn ocr_page(&self, input: OcrPageInput) -> Result<OcrPageOutput> {
+        // Rate limit the request.
+        self.rate_limiter.acquire_one().await;
+
+        // Call the raw driver (it loads the image internally).
+        let response = self
+            .driver
+            .raw_completion(
+                &self.ocr_opts.model,
+                &self.prompt_text,
+                &input.image,
+                &self.ocr_opts.llm_opts,
+                &self.mem_limiter,
+            )
+            .await;
+
+        match response {
+            Ok(crate::drivers::RawCompletionResponse { text, token_usage }) => {
+                Ok(OcrPageOutput {
+                    text: Some(text),
+                    errors: Vec::new(),
+                    analysis: None,
+                    estimated_cost: None,
+                    token_usage,
+                })
+            }
+            Err(e) => Ok(OcrPageOutput {
+                text: None,
+                errors: vec![format!("Raw driver error: {e}")],
+                analysis: None,
+                estimated_cost: None,
+                token_usage: None,
+            }),
+        }
+    }
+}

--- a/src/queues/ocr/engines/textract.rs
+++ b/src/queues/ocr/engines/textract.rs
@@ -18,20 +18,18 @@ use uuid::Uuid;
 
 use crate::aws::load_aws_config;
 use crate::cmd::ocr::OcrOpts;
-use crate::drivers::LlmOpts;
 use crate::images::ImageEncoding;
-use crate::mem_limit::{MEM_PERMIT_DEADLOCK_TIMEOUT, MemLimiter};
+use crate::mem_limit::MemLimiter;
 use crate::prelude::*;
 
 use crate::async_utils::JoinWorker;
-use crate::rate_limit::{RateLimit, RateLimitPeriod};
 use crate::retry::{
     DEFAULT_JITTER, IsKnownTransient, retry_result_ok, retry_with_backoff,
     try_potentially_transient,
 };
 
 use super::file::OcrFileEngine;
-use super::page::{OcrPageEngine, OcrPageInput, OcrPageOutput};
+use super::page::{OcrPageEngine, OcrPageInput, OcrPageOutput, create_rate_limiter};
 use crate::queues::ocr::{OcrInput, OcrOutput};
 use crate::queues::work::{WorkInput, WorkOutput, WorkStatus};
 
@@ -42,19 +40,6 @@ const ESTIMATED_PAGE_COST: f64 = 0.004;
 async fn create_textract_client() -> Result<aws_sdk_textract::Client> {
     let config = load_aws_config().await?;
     Ok(aws_sdk_textract::Client::new(&config))
-}
-
-/// Create a rate limiter, defaulting as best we can.
-fn create_rate_limiter(concurrency_limit: usize, llm_opts: &LlmOpts) -> RateLimiter {
-    // If we don't have a rate limit, set one based on the concurrency limit.
-    //
-    // TODO: FUTURE BREAKING: We may want to remove the default rate limit, but
-    // that would be a breaking change.
-    let rate_limit = llm_opts
-        .rate_limit
-        .clone()
-        .unwrap_or_else(|| RateLimit::new(concurrency_limit, RateLimitPeriod::Second));
-    rate_limit.to_rate_limiter()
 }
 
 /// OCR engine wrapping the synchronous AWS Textract `analyze_document` API.
@@ -81,12 +66,7 @@ impl TextractOcrPageEngine {
     ) -> Result<(Arc<dyn OcrPageEngine>, JoinWorker)> {
         let client = create_textract_client().await?;
         let rate_limiter = create_rate_limiter(concurrency_limit, &ocr_opts.llm_opts);
-        let mem_limiter = ocr_opts
-            .llm_opts
-            .page_memory_limit
-            .as_ref()
-            .map(|ml| ml.to_mem_limiter(Some(MEM_PERMIT_DEADLOCK_TIMEOUT)))
-            .unwrap_or_else(MemLimiter::unlimited);
+        let mem_limiter = ocr_opts.llm_opts.mem_limiter();
 
         Ok((
             Arc::new(Self {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -26,6 +26,9 @@ static LLAMA_SERVER_API_KEY: &str = "sk-1234";
 /// Default model to use for `llama-server` in tests. Should be a small, fast
 /// model with at least some very basic OCR abilities.
 static LLAMA_SERVER_MODEL: &str = "unsloth/gemma-4-E2B-it-GGUF:Q4_K_M";
+/// GLM-OCR model (a limited, OCR-only model pretending to be an LLM), which we
+/// use to test our GLM-OCR codepath.
+static LLAMA_SERVER_GLM_OCR_MODEL: &str = "ggml-org/GLM-OCR-GGUF:F16";
 
 /// Cheap models that route to their provider's native adapter (the default
 /// driver). Each requires the matching API key in `.env`.
@@ -232,6 +235,22 @@ fn test_ocr_llama() {
         .args(["--model", LLAMA_SERVER_MODEL])
         // Rasterization is needed for PDFs with llama-server.
         .arg("--rasterize")
+        .assert()
+        .success();
+}
+
+#[test]
+#[ignore = "Needs `llama-server` running with GLM-OCR model"]
+fn test_ocr_glm_llama() {
+    cmd()
+        .with_llama_server_env()
+        .arg("ocr")
+        .arg("tests/fixtures/ocr/input.csv")
+        .args(["--base-dir", "tests/fixtures/"])
+        .args(["--jobs", "3"])
+        .args(["--model", LLAMA_SERVER_GLM_OCR_MODEL])
+        .arg("--rasterize")
+        // GLM-OCR uses the raw driver path (no prompt template or schema).
         .assert()
         .success();
 }


### PR DESCRIPTION
[GLM-OCR](https://github.com/zai-org/GLM-OCR) is a _tiny_, "open weight" OCR model. Which it's fast, cheap and possible to run 100% locally with an appropriate GPU. GLM-OCR _pretends_ to be a Visual LLM, but it only accepts 4 specific prompts, and it only does OCR. Normally, GLM-OCR is never used standalone, but rather as part of a larger stack like [PaddleOCR](https://github.com/PADDLEPADDLE/PADDLEOCR) that provides image segmentation and text detection.

This PR adds basic standalone GLM-OCR support. You know, the mode I just said you're not supposed to use. 🤦 Here's what I've noticed:

- Without segmentation, the OCR quality is wildly inconsistent, ranging from state-of-the-art to just outright missing larger chunks of text.
- There's some level of text-layout complexity below which it's fine, or even great. But once you pass that threshold, it breaks.
- [Further manual testing on PaddleOCR](https://aistudio.baidu.com/paddleocr) suggests that a more complete stack should provide _excellent_ results even on complex images.

So this patch basically provides just enough support to benchmark the "standalone" mode. This could probably be easily adapted to benchmark standalone PaddleOCR models, which I would expect to have similar profiles.